### PR TITLE
Disabled pytest in current workflow

### DIFF
--- a/.github/workflows/python-linting.yml
+++ b/.github/workflows/python-linting.yml
@@ -27,6 +27,6 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82,E101,E112 --show-source --statistics
         # exit-zero treats all errors as warnings.
         flake8 . --count --exit-zero --max-complexity=10 --statistics
-    - name: Test with pytest
-      run: |
-        pytest
+        # - name: Test with pytest
+        #   run: |
+        #     pytest


### PR DESCRIPTION
When creating the repository I included workflows to automatically lint, run `pytest` and deploy documentation to GitHub pages. We've realized that right now that we are still developing the documentation and creating appropiate tests, having to override checks is cumbersome. I'd rather we disable them for the moment being and re-enable them in the short future.