### PR TITLE
Feature/update yolo class

### DIFF
--- a/src/perception/vision_cone_detector/src/detector/__init__.py
+++ b/src/perception/vision_cone_detector/src/detector/__init__.py
@@ -1,2 +1,2 @@
-from . import detector
+from .detector import *
 from . import utils

--- a/src/perception/vision_cone_detector/src/detector/detector.py
+++ b/src/perception/vision_cone_detector/src/detector/detector.py
@@ -36,11 +36,11 @@ class YoloDetector:
         :return: List containing Darknet detections
         :rtype: List[darknet.DETECTION]
         """
-        frame = cv2.resize(frame,
+        frame = cv2.resize(img,
                            (self.darknet_width, self.darknet_height),
                            interpolation=cv2.INTER_LINEAR)
         darknet_image = darknet.make_image(self.darknet_width, self.darknet_height, 3)
-        darknet.copy_image_from_bytes(darknet_image, frame.to_bytes())
+        darknet.copy_image_from_bytes(darknet_image, frame.tobytes())
 
         detections = darknet.detect_image(self.network, self.names, darknet_image)
         darknet.free_image(darknet_image)

--- a/src/perception/vision_cone_detector/src/detector/detector.py
+++ b/src/perception/vision_cone_detector/src/detector/detector.py
@@ -6,211 +6,43 @@ by darknet.py, a python wrapper for darknet.
 @author: Jacobo Pindado
 @date: 20211214
 """
+import os
 import sys
-import argparse
-import configparser
-from pathlib import Path
+from typing import List, Tuple, Union
+
 import cv2
 import numpy as np
 
-from typing import List, Tuple
-from .utils.BaseClasses import ImageSize, Point, Rectangle, Object
-from .utils.ImageSlicer import Slice, SliceIterator
 from .utils import darknet
 
 
-class Detector:
+class YoloDetector:
+    def __init__(self,
+                 cfg: Union[str, bytes, os.PathLike],
+                 data: Union[str, bytes, os.PathLike],
+                 weights: Union[str, bytes, os.PathLike]):
 
-    def __init__(self, cfg: configparser.ConfigParser,
-                 input_size: ImageSize = None,
-                 slice_size: ImageSize = None):
-        self.cfg = cfg['YOLO']['config']
-        self.data = cfg['YOLO']['data']
-        self.weights = cfg['YOLO']['weights']
+        self.network, self.names, self.colors = darknet.load_network(cfg, data, weights)
+        self.darknet_width = darknet.network_width(self.network)
+        self.darknet_height = darknet.network_height(self.network)
 
-        # TODO number - name translation
-        self.network, self.names, self.colors = darknet.load_network(self.cfg, self.data,
-                                                                     self.weights)
+    def predict_from_image(self, img: np.ndarray) -> List[darknet.DETECTION]:
+        """Method to infere image through a given darknet network.
 
-        # TODO this shouldn't be hardcoded
-        self.slice_size = ImageSize(480, 360, 0)
+        :param img: Numpy array with image data. Channel order **must** be RGB.
+                    When using cv2 for capturing, this should be taken into
+                    account since it works with BRG.
+        :type img:  np.ndarray
+        :return: List containing Darknet detections
+        :rtype: List[darknet.DETECTION]
+        """
+        frame = cv2.resize(frame,
+                           (self.darknet_width, self.darknet_height),
+                           interpolation=cv2.INTER_LINEAR)
+        darknet_image = darknet.make_image(self.darknet_width, self.darknet_height, 3)
+        darknet.copy_image_from_bytes(darknet_image, frame.to_bytes())
 
-        self.input_size = input_size
-        if input_size is not None:
-            self.output_size = SliceIterator.output_image_size(self.input_size, self.slice_size)
-        else:
-            self.output_size = None
+        detections = darknet.detect_image(self.network, self.names, darknet_image)
+        darknet.free_image(darknet_image)
 
-    def detect_image(self, image: np.ndarray, UoO_threshold: int = 0.6):
-
-        if self.input_size is None:
-            self.input_size = ImageSize(image.shape[1], image.shape[0])
-        if self.output_size is None:
-            self.output_size = SliceIterator.output_image_size(self.input_size, self.slice_size)
-
-        object_dict = dict()
-        final_objects = list()
-
-        iterator = SliceIterator(image, self.input_size, self.slice_size,
-                                 output_image_dims=self.output_size)
-        for col, row, slice, _ in iterator:
-            predictions = self.detect_from_slice(slice)
-
-            object_dict[(col, row)] = (slice, predictions)
-            if col > 0:
-                Detector.join_objects((col - 1, row), predictions, object_dict, UoO_threshold)
-            if row > 0:
-                Detector.join_objects((col, row - 1), predictions, object_dict, UoO_threshold)
-            if col > 0 and row > 0:
-                Detector.join_objects((col - 1, row - 1), predictions, object_dict, UoO_threshold)
-
-        for _, object_list in object_dict.values():
-            if object_list is not None:
-                final_objects.extend(o.get_shifted(Point(iterator.pad_width, iterator.pad_height),
-                                                   reverse=True) for o in object_list)
-
-        return final_objects
-
-    def detect_video(video_path: str, output_path: str,
-                     detector_cfg: configparser.ConfigParser,
-                     UoO_threshold: int = 0.6):
-        # from tqdm import tqdm
-        cap = cv2.VideoCapture(video_path)
-
-        frame_width = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
-        frame_height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
-        fps = cap.get(cv2.CAP_PROP_FPS)
-        # frames = cap.get(cv2.CAP_PROP_FRAME_COUNT)
-
-        input_size = ImageSize(frame_width, frame_height)
-        detector = Detector(detector_cfg, input_size=input_size)
-
-        fourcc = cv2.VideoWriter_fourcc(*'H264')
-        out = cv2.VideoWriter(output_path, fourcc, fps, (frame_width, frame_height))
-        # progress_bar = tqdm(total=frames)
-        while(cap.isOpened()):
-            # progress_bar.update(1)
-            ret, frame = cap.read()
-
-            if ret:
-                objects = detector.detect_image(frame)
-                Detector.draw_objects(frame, objects)
-
-                out.write(frame)
-            else:
-                break
-
-        out.release()
-        cap.release()
-
-    def union_over_overlap(rect1: Rectangle, rect2: Rectangle):
-        return rect1.union_area(rect2) / rect1.overlapping_rectangle(rect2).area()
-
-    def detect_from_slice(self, slice: Slice):
-        image = darknet.nparray_to_image(slice.slice_image)
-
-        predictions = darknet.detect_image(self.network, self.names, image)
-        darknet.free_image(image)
-        return Detector.predictions_to_object(predictions, slice)
-
-    def join_objects(other_position: Tuple[int, int],
-                     predictions: List[Object],
-                     object_dict: dict,
-                     UoO_threshold: float):
-        _, objects = object_dict[other_position]
-        for p in predictions:
-            candidate_objects = list()
-            for o in objects:
-                UoO = Detector.union_over_overlap(o, p)
-
-                if UoO >= UoO_threshold:
-                    candidate_objects.append((o, UoO))
-
-            if len(candidate_objects) != 0:
-                obj = max(candidate_objects, key=lambda k: k[1])[0]
-
-                objects.remove(obj)
-                predictions.remove(p)
-                objects.append(obj.overlapping_rectangle(p))
-
-    def predictions_to_object(predictions: List[Object], slice: Slice):
-        rObjects = list()
-        for pred in predictions:
-            center = Point(pred[2][0], pred[2][1])
-            width = pred[2][2]
-            height = pred[2][3]
-
-            object = Object.from_YOLO(center, width, height, '0', slice.image_size)
-            object.to_int()
-
-            if object.area() > 0:
-                rObjects.append(object.get_shifted(slice.tl))
-
-        return rObjects
-
-    def draw_objects(image: np.ndarray, objects: List[Object]):
-        for o in objects:
-            cv2.rectangle(image, o.tl.tuple(), o.br.tuple(), (0, 0, 255), thickness=2)
-
-
-def argparser_setup():
-    parser = argparse.ArgumentParser(description='Detect cones from given\
-                                     image with trained weights')
-    subparsers = parser.add_subparsers(help='command')
-
-    image_parser = subparsers.add_parser('image', help='Detect on images')
-    image_parser.set_defaults(func=image_command)
-    image_parser.add_argument("configfile", metavar='<cfg>',
-                              help="Path to config file", type=Path)
-    image_parser.add_argument("imagepath", metavar='<img path>',
-                              help="Path to image to detect", type=Path)
-    image_parser.add_argument("--outfile", metavar='<out path>',
-                              help="Path where resulting image will be outputed. If not specified,\
-                              cone positions will be printed",
-                              type=Path)
-
-    video_parser = subparsers.add_parser('video', help='Detect on videos')
-    video_parser.set_defaults(func=video_command)
-    video_parser.add_argument('configfile', metavar='<cfg>',
-                              help="Path to config file", type=Path)
-    video_parser.add_argument("videopath", metavar='<vid path>',
-                              help="Path to video to detect", type=Path)
-    video_parser.add_argument("outfile", metavar='<out path>',
-                              help="Path where resulting video will be outputed",
-                              type=Path)
-    return parser
-
-
-def image_command(args: argparse.ArgumentParser):
-    config = configparser.ConfigParser()
-    config.read(str(args.configfile.resolve()))
-    input_file = str(args.imagepath.resolve())
-    output_file = str(args.outfile.resolve()) if args.outfile is not None else None
-    detector = Detector(config)
-
-    image = cv2.imread(input_file)
-    objects = detector.detect_image(image)
-    if output_file is None:
-        print(objects)
-    else:
-        Detector.draw_objects(image, objects)
-        cv2.imwrite(output_file, image)
-
-
-def video_command(args):
-    config = configparser.ConfigParser()
-    config.read(str(args.configfile.resolve()))
-    input_file = str(args.videopath.resolve())
-    output_file = str(args.outfile.resolve())
-
-    Detector.detect_video(input_file, output_file, config)
-
-
-def configparser_read(file: str):
-    return configparser.ConfigParser().read(file)
-
-
-if __name__ == "__main__":
-    args = argparser_setup().parse_args()
-    args.func(args)
-    sys.exit()
+        return detections

--- a/src/perception/vision_cone_detector/src/detector/detector.py
+++ b/src/perception/vision_cone_detector/src/detector/detector.py
@@ -7,8 +7,7 @@ by darknet.py, a python wrapper for darknet.
 @date: 20211214
 """
 import os
-import sys
-from typing import List, Tuple, Union
+from typing import List, Union
 
 import cv2
 import numpy as np

--- a/src/perception/vision_cone_detector/src/detector/utils/darknet.py
+++ b/src/perception/vision_cone_detector/src/detector/utils/darknet.py
@@ -193,48 +193,8 @@ def nparray_to_image(img):
 
 
 hasGPU = True
-if os.name == "nt":
-    cwd = os.path.dirname(__file__)
-    os.environ['PATH'] = cwd + ';' + os.environ['PATH']
-    winGPUdll = os.path.join(cwd, "yolo_cpp_dll.dll")
-    winNoGPUdll = os.path.join(cwd, "yolo_cpp_dll_nogpu.dll")
-    envKeys = list()
-    for k, v in os.environ.items():
-        envKeys.append(k)
-    try:
-        try:
-            tmp = os.environ["FORCE_CPU"].lower()
-            if tmp in ["1", "true", "yes", "on"]:
-                raise ValueError("ForceCPU")
-            else:
-                print("Flag value {} not forcing CPU mode".format(tmp))
-        except KeyError:
-            # We never set the flag
-            if 'CUDA_VISIBLE_DEVICES' in envKeys:
-                if int(os.environ['CUDA_VISIBLE_DEVICES']) < 0:
-                    raise ValueError("ForceCPU")
-            try:
-                global DARKNET_FORCE_CPU
-                if DARKNET_FORCE_CPU:
-                    raise ValueError("ForceCPU")
-            except NameError as cpu_error:
-                print(cpu_error)
-        if not os.path.exists(winGPUdll):
-            raise ValueError("NoDLL")
-        lib = CDLL(winGPUdll, RTLD_GLOBAL)
-    except (KeyError, ValueError):
-        hasGPU = False
-        if os.path.exists(winNoGPUdll):
-            lib = CDLL(winNoGPUdll, RTLD_GLOBAL)
-            print("Notice: CPU-only mode")
-        else:
-            # Try the other way, in case no_gpu was compile but not renamed
-            lib = CDLL(winGPUdll, RTLD_GLOBAL)
-            print("Environment variables indicated a CPU run, but we didn't find {}. \
-                  Trying a GPU run anyway.".format(winNoGPUdll))
-else:
-    lib_path = os.path.join(os.path.dirname(__file__), "libdarknet.so")
-    lib = CDLL(lib_path, RTLD_GLOBAL)
+lib_path = os.path.join(os.path.dirname(__file__), "libdarknet.so")
+lib = CDLL(lib_path, RTLD_GLOBAL)
 
 lib.network_width.argtypes = [c_void_p]
 lib.network_width.restype = c_int


### PR DESCRIPTION
Until now, due to memory constraints (and lack of knowledge), images were separated into slices and then passed to `darknet` one by one, to later be joined. This is no longer necessary, since we can infer on the whole image, which greatly simplifies everything.

Also removed Windows import case in `darknet.py` since this classes should only run on Linux.