### PR TITLE
Changed how distortion is taken into account

### DIFF
--- a/src/perception/vision_cone_detector/src/estimator_handle.py
+++ b/src/perception/vision_cone_detector/src/estimator_handle.py
@@ -48,8 +48,6 @@ class EstimatorHandle():
 
         encoding = "passthrough" if camera["img_format"] == "RGB" else "rgb8"
         image = CvBridge().imgmsg_to_cv2(msg, desired_encoding=encoding)
-        if image.shape != (1088, 1920, 3):
-            image = cv2.resize(image, (1920, 1088))
 
         estimated_points = self.estimator.map_from_image(image)
 


### PR DESCRIPTION
Previously, images where inferred on using the pipeline and then undistorted.
https://github.com/ARUSfs/DRIVERLESS/blob/8ec1fa0c435932fa068be1366e8d85f1a5d90d3f/src/perception/vision_cone_detector/src/estimator.py#L58-L85

Now the opposite is done, we first undistort the whole image, then feed it to the rest of the estimation pipeline:
https://github.com/ARUSfs/DRIVERLESS/blob/6b64f6de146733b523b0c6a139ddb8d98fb5a0a0/src/perception/vision_cone_detector/src/estimator.py#L70-L76

Also fixed error where points where multiplied by the camera matrix, instead of its inverse.