### PR TITLE
Redo Dalaunay path calculation

### DIFF
--- a/src/common/common_msgs/CMakeLists.txt
+++ b/src/common/common_msgs/CMakeLists.txt
@@ -21,6 +21,8 @@ find_package(catkin REQUIRED COMPONENTS
    CarState.msg
    Camera_dofs.msg
    Mission.msg
+   Simplex.msg
+   Triangulation.msg
  )
 
 ## Generate services in the 'srv' folder

--- a/src/common/common_msgs/msg/Simplex.msg
+++ b/src/common/common_msgs/msg/Simplex.msg
@@ -1,0 +1,1 @@
+geometry_msgs/Point[] simplex

--- a/src/common/common_msgs/msg/Triangulation.msg
+++ b/src/common/common_msgs/msg/Triangulation.msg
@@ -1,0 +1,1 @@
+common_msgs/Simplex[] simplices

--- a/src/common/visualization/config/interface.yaml
+++ b/src/common/visualization/config/interface.yaml
@@ -1,5 +1,6 @@
 # Topics
 topic_route: "route"
-topic_map: "perception_map"
+topic_map: "/vision_cone_detector/estimated_map/"
 topic_pursuit: "pursuit_point"
 topic_state: "state"
+topic_delaunay: "/delaunay_detector/simplices"

--- a/src/common/visualization/rviz/interface.rviz
+++ b/src/common/visualization/rviz/interface.rviz
@@ -52,7 +52,7 @@ Visualization Manager:
       Reference Frame: <Fixed Frame>
       Value: true
     - Class: rviz/MarkerArray
-      Enabled: false
+      Enabled: true
       Marker Topic: /visualization_cones
       Name: Detected cones
       Namespaces:
@@ -80,7 +80,7 @@ Visualization Manager:
         Value: true
       Zoom Factor: 1
     - Class: rviz/Camera
-      Enabled: false
+      Enabled: true
       Image Rendering: background and overlay
       Image Topic: ""
       Name: Camera 2
@@ -113,7 +113,7 @@ Visualization Manager:
       Buffer Length: 1
       Class: rviz/Path
       Color: 0; 0; 0
-      Enabled: false
+      Enabled: true
       Head Diameter: 0.10000000149011612
       Head Length: 0.20000000298023224
       Length: 0.30000001192092896

--- a/src/common/visualization/src/interface_handle.py
+++ b/src/common/visualization/src/interface_handle.py
@@ -176,6 +176,10 @@ class InterfaceHandle():
         marker.action = Marker.MODIFY
         marker.scale.x = 0.1
         marker.color.a = 1.0
+        marker.pose.orientation.x = 0.0
+        marker.pose.orientation.y = 0.0
+        marker.pose.orientation.z = 0.0
+        marker.pose.orientation.w = 1.0
 
         marker.points = list()
         for s in simplices.simplices:

--- a/src/common/visualization/src/interface_handle.py
+++ b/src/common/visualization/src/interface_handle.py
@@ -5,8 +5,8 @@
 """
 from itertools import combinations
 
-from common_msgs.msg import Map, Trajectory, Simplex, Triangulation
-from geometry_msgs.msg import PoseStamped, Polygon
+from common_msgs.msg import Map, Trajectory, Triangulation
+from geometry_msgs.msg import PoseStamped
 from visualization_msgs.msg import Marker, MarkerArray
 from nav_msgs.msg import Path
 from geometry_msgs.msg import Point

--- a/src/perception/vision_cone_detector/src/estimator_handle.py
+++ b/src/perception/vision_cone_detector/src/estimator_handle.py
@@ -4,7 +4,6 @@
 @author: Jacobo Pindado
 @date 20221113
 """
-import cv2
 import rospy
 from sensor_msgs.msg import Image
 from geometry_msgs.msg import Point

--- a/src/perception/vision_cone_detector/src/keypoints/net_train.py
+++ b/src/perception/vision_cone_detector/src/keypoints/net_train.py
@@ -45,8 +45,7 @@ def train_model(kNet, epochs, dataset_images_path,
     dataloader = {'Train': DataLoader(datasetTrain, batch_train,
                                       shuffle=True, drop_last=True),
                   'Validation': DataLoader(datasetValidation, batch_validation,
-                                           shuffle=True, drop_last=True)
-                 }
+                                           shuffle=True, drop_last=True)}
 
     # Create optimizer for train
     optimizer = torch.optim.Adam(kNet.parameters(), lr=lr)

--- a/src/perception/vision_cone_detector/src/keypoints/optimize_hiper.py
+++ b/src/perception/vision_cone_detector/src/keypoints/optimize_hiper.py
@@ -105,8 +105,7 @@ def train_evaluate(parameters):
     dataloader = {'Train': DataLoader(datasetTrain, batch_train,
                                       shuffle=True, drop_last=True),
                   'Validation': DataLoader(datasetValidation, batch_validation,
-                                           shuffle=True, drop_last=True)
-                 }
+                                           shuffle=True, drop_last=True)}
 
     # Create optimizer for train
     optimizer = torch.optim.Adam(kNet.parameters(), lr=lr)

--- a/src/perception/vision_cone_detector/src/main.py
+++ b/src/perception/vision_cone_detector/src/main.py
@@ -8,10 +8,12 @@
 import rospy
 from estimator_handle import EstimatorHandle
 
+
 def main():
     rospy.init_node("vision_cone_detector", anonymous=True)
     EstimatorHandle()
     rospy.spin()
+
 
 if __name__ == '__main__':
     try:

--- a/src/planning/delaunay_detector/config/delaunay.yaml
+++ b/src/planning/delaunay_detector/config/delaunay.yaml
@@ -1,5 +1,5 @@
 # Topics names of planning node
-topic_map: 'perception_map'
+topic_map: '/vision_cone_detector/estimated_map'
 topic_route: 'route'
 
 

--- a/src/planning/delaunay_detector/src/planning.py
+++ b/src/planning/delaunay_detector/src/planning.py
@@ -14,9 +14,7 @@ from sklearn.neighbors import NearestNeighbors
 
 from common_msgs.msg import Simplex, Triangulation
 from geometry_msgs.msg import Point
-from visualization_msgs.msg import Marker
 
-from utils import spline
 
 MAX_DISTANCE = 8
 
@@ -37,7 +35,6 @@ class PlanningSystem():
         self.delaunay_publisher = rospy.Publisher('/delaunay_detector/simplices',
                                                   Triangulation,
                                                   queue_size=1)
-
 
     def update_tracklimits(self, cones: list):
         self.colours = list()

--- a/src/planning/delaunay_detector/src/planning.py
+++ b/src/planning/delaunay_detector/src/planning.py
@@ -43,7 +43,7 @@ class PlanningSystem():
         self.colours = list()
         cone_points = list()
         for c in cones:
-            if c.confidence > 0.9:
+            if c.confidence > 0.5:
                 cone_points.append((c.position.x, c.position.y))
                 self.colours.append(c.color)
         self.cones = np.array(cone_points)
@@ -86,6 +86,9 @@ class PlanningSystem():
         route[0, :] = np.zeros((1, 2))
         route[1:, :] = midpoints[path_indices]
 
+        # TODO: I don't think using a spline to "smooth" the route is worth since
+        # pure_pursuit will do it anyway with parameter changes. As of now it will
+        # remain un-splined.
         return route
 
     def get_distance(self, p1, p2):

--- a/src/planning/delaunay_detector/src/planning_handle.py
+++ b/src/planning/delaunay_detector/src/planning_handle.py
@@ -43,24 +43,15 @@ class PlanningHandle():
         self.publish_msg()
 
     def publish_msg(self):
-
-        route, weight = self.planning_system.calculate_path()
-
-        msg = self.transform_to_msg_trajectory(route)
-        rospy.loginfo(msg)
-        rospy.loginfo(weight)
-        self.pub_route.publish(msg)
-
-    def transform_to_msg_trajectory(self, route: list):
-
+        route = self.planning_system.calculate_path()
         msg = Trajectory()
-        points = []
-        for p in route:
+        msg.trajectory = list()
+        for midpoint in route:
             point = Point()
-            point.x = p[0]
-            point.y = p[1]
+            point.x = midpoint[0]
+            point.y = midpoint[1]
             point.z = 0
-            points.append(point)
+            msg.trajectory.append(point)
 
-        msg.trajectory = points
-        return msg
+        rospy.loginfo(msg)
+        self.pub_route.publish(msg)


### PR DESCRIPTION
The previous implementation of delaunay triangulation and path-finding for extracting the middle path between both sides of the track was too inefficient and couldn't keep up with perception. 

The main reasons it was so slow were:
- Every midpoint was considered, even those that where impossible (sides too long)
- All these midpoints where used to calculate the optimal tree and then the optimal path, which resulted in an awful complexity (at least exponential, didn't bother to find out exactly).
- The tree was built using recursion (👍 for algorithm, 👎 for speed)
- The cost function wasn't specially fast

Instead of trying to fix some of these problems, I've gone for doing it from scratch. As an overview of how it works

We calculate the Daulay simplices and discard those with very long sides. We then discard the simplices whose 3 vertices are of the same color:
https://github.com/ARUSfs/DRIVERLESS/blob/119b3375f339fa90ed71a80526ba82aa50914352/src/planning/delaunay_detector/src/planning.py#L55-L63

We publish the selected simplices for visualization in RViz:
https://github.com/ARUSfs/DRIVERLESS/blob/119b3375f339fa90ed71a80526ba82aa50914352/src/planning/delaunay_detector/src/planning.py#L65

Finally, we obtain the path by using a greedy algorithm: just choose the closest midpoint not already in the path:
https://github.com/ARUSfs/DRIVERLESS/blob/119b3375f339fa90ed71a80526ba82aa50914352/src/planning/delaunay_detector/src/planning.py#L67-L80

A lot of optimization could be extracted, but I'm in a bit of a rush and it's more than enough for now since the midpath is quite good and it can run at over 300Hz! (at least on my machine 😛).