### PR TITLE
Feature/custom camera node

### DIFF
--- a/src/perception/imycamera/CMakeLists.txt
+++ b/src/perception/imycamera/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.0.2)
+project(imycamera)
+
+find_package(catkin REQUIRED COMPONENTS
+  rospy
+  std_msgs
+)
+
+catkin_package(
+)
+
+include_directories(
+  ${catkin_INCLUDE_DIRS}
+)

--- a/src/perception/imycamera/config/camera.yaml
+++ b/src/perception/imycamera/config/camera.yaml
@@ -1,0 +1,5 @@
+capture_device: 2
+capture_fps: 15.0
+capture_width: 2048
+capture_height: 1536
+frame: 'camera1'

--- a/src/perception/imycamera/launch/camera.launch
+++ b/src/perception/imycamera/launch/camera.launch
@@ -1,0 +1,5 @@
+<launch>
+  <node pkg="imycamera" name="camera1" type="main.py">
+    <rosparam command="load" file="$(find imycamera)/config/camera.yaml"/>
+  </node>
+</launch>

--- a/src/perception/imycamera/package.xml
+++ b/src/perception/imycamera/package.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>imycamera</name>
+  <version>0.1.0</version>
+  <description>Custom implementation of cv_camera, which doesnt support not-buffering.</description>
+
+  <maintainer email="pindado.jacobo@gmail.com">Jacobo Pindado</maintainer>
+
+
+  <license>TODO</license>
+
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>rospy</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_export_depend>rospy</build_export_depend>
+  <build_export_depend>std_msgs</build_export_depend>
+  <exec_depend>rospy</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+
+
+  <export>
+
+  </export>
+</package>

--- a/src/perception/imycamera/src/main.py
+++ b/src/perception/imycamera/src/main.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Script to initialize the visual perception node
+
+@author: Jacobo Pindado
+@date 20221113
+"""
+
+import rospy
+import cv2
+from cv_bridge import CvBridge
+from sensor_msgs.msg import Image
+from std_msgs.msg import Header
+
+
+if __name__ == '__main__':
+    rospy.init_node('imycamera', anonymous=True)
+
+    capture_device = rospy.get_param('~capture_device', 0)
+    capture_fps = rospy.get_param('~capture_fps', 30.0)
+    capture_width = rospy.get_param('~capture_width', 1280)
+    capture_height = rospy.get_param('~capture_height', 960)
+    camera_frame = rospy.get_param('~camera_frame', None)
+
+    pub = rospy.Publisher('~image_raw', Image, queue_size=1)
+
+    capture = cv2.VideoCapture(capture_device, cv2.CAP_V4L2)
+    capture.set(cv2.CAP_PROP_FRAME_WIDTH, capture_width)
+    capture.set(cv2.CAP_PROP_FRAME_HEIGHT, capture_height)
+    capture.set(cv2.CAP_PROP_FPS, capture_fps)
+    capture.set(cv2.CAP_PROP_FOURCC, cv2.VideoWriter_fourcc(*'MJPG'))
+    bridge = CvBridge()
+
+    rate = rospy.Rate(capture_fps)
+    try:
+        header = Header()
+        header.frame_id = camera_frame
+
+        while not rospy.is_shutdown():
+            while not capture.grab():
+                continue
+
+            _, image = capture.retrieve()
+            if image is not None:
+                header.stamp = rospy.get_rostime()
+                image_msg = bridge.cv2_to_imgmsg(image,
+                                                 encoding='passthrough',
+                                                 header=header)
+
+                pub.publish(image_msg)
+
+            rate.sleep()
+
+        # If we exit the while loop, release the camera from opencv
+        capture.release()
+    except rospy.ROSInterruptException:
+        capture.release()

--- a/src/perception/vision_cone_detector/config/vision.yaml
+++ b/src/perception/vision_cone_detector/config/vision.yaml
@@ -9,7 +9,7 @@ kpt:
   img_size: [80, 80]
 
 camera:
-  topic: "/cam/image_raw"
+  topic: "/camera1/image_raw"
   device: "/dev/camera0"
   camera_mat: [1, 0, 0,
                0, 1, 0,

--- a/src/perception/vision_cone_detector/launch/vision_cone_detector.launch
+++ b/src/perception/vision_cone_detector/launch/vision_cone_detector.launch
@@ -1,8 +1,5 @@
 <launch>
-  <node pkg="cv_camera" type="cv_camera_node" name="cam">
-    <param name="rate" value="10.0"/>
-    <param name="file" value="/home/jacobo/Downloads/C-ART/vid.mp4"/>
-  </node>
+  <include file="$(find imycamera)/launch/camera.launch"/>
   <node pkg="vision_cone_detector" name="vision_cone_detector" type="main.py">
     <rosparam command="load" file="$(find vision_cone_detector)/config/vision.yaml"/>
   </node>


### PR DESCRIPTION
To use the 'cheap' cameras, we need to use specific parameters with OpenCV, which [cv_camera](http://wiki.ros.org/cv_camera) at this moment. No `camera_info` message is being sent at this moment.