### PR TITLE
Reintroduced CarState

### DIFF
--- a/src/common/common_msgs/CMakeLists.txt
+++ b/src/common/common_msgs/CMakeLists.txt
@@ -22,6 +22,7 @@ find_package(catkin REQUIRED COMPONENTS
    Mission.msg
    Simplex.msg
    Triangulation.msg
+   CarState.msg
  )
 
 ## Generate services in the 'srv' folder

--- a/src/common/common_msgs/msg/CarState.msg
+++ b/src/common/common_msgs/msg/CarState.msg
@@ -1,0 +1,11 @@
+std_msgs/Header header
+
+float64 x #[m]
+float64 y #[m]
+float64 z #[m]
+float64 vx #[m/s]
+float64 vy #[m/s]
+float64 vz #[m/s]
+float64 roll #[rad]
+float64 pitch #[rad]
+float64 yaw #[rad]


### PR DESCRIPTION
During PR #26, the message `CarState.msg` was removed since seemingly it was deprecated. It has however become apparent that it was used for interfacing with `fssim`, causing problems while running it. 

This hotfix just reintroduces the original message as is. 