### PR TITLE
Feature/change delaunay visualization

### DIFF
--- a/src/planning/delaunay_detector/config/delaunay.yaml
+++ b/src/planning/delaunay_detector/config/delaunay.yaml
@@ -2,7 +2,7 @@
 topic_map: 'perception_map'
 topic_route: 'route'
 topic_simplices: 'simplices'
-send_simplices_marker: true],
+send_simplices_marker: true,
 
 # Hiperparameters of delaunay detector
 W_DISTANCE: 1

--- a/src/planning/delaunay_detector/config/delaunay.yaml
+++ b/src/planning/delaunay_detector/config/delaunay.yaml
@@ -2,7 +2,7 @@
 topic_map: 'perception_map'
 topic_route: 'route'
 topic_simplices: 'simplices'
-send_simplices_marker: true,
+send_simplices_marker: true
 
 # Hiperparameters of delaunay detector
 W_DISTANCE: 1

--- a/src/planning/delaunay_detector/config/delaunay.yaml
+++ b/src/planning/delaunay_detector/config/delaunay.yaml
@@ -1,7 +1,8 @@
 # Topics names of planning node
-topic_map: '/vision_cone_detector/estimated_map'
+topic_map: 'perception_map'
 topic_route: 'route'
-
+topic_simplices: 'simplices'
+send_simplices_marker: true],
 
 # Hiperparameters of delaunay detector
 W_DISTANCE: 1

--- a/src/planning/delaunay_detector/src/planning.py
+++ b/src/planning/delaunay_detector/src/planning.py
@@ -86,7 +86,7 @@ class PlanningSystem():
         # TODO: I don't think using a spline to "smooth" the route is worth since
         # pure_pursuit will do it anyway with parameter changes. As of now it will
         # remain un-splined.
-        return route
+        return route, preproc_simplices
 
     def get_distance(self, p1, p2):
         p1b = p1.tobytes()

--- a/src/planning/delaunay_detector/src/planning_handle.py
+++ b/src/planning/delaunay_detector/src/planning_handle.py
@@ -4,8 +4,10 @@
 @date: 20220504
 """
 
-from common_msgs.msg import Map
-from common_msgs.msg import Trajectory
+from itertools import combinations
+
+from common_msgs.msg import Map, Trajectory
+from visualization_msgs.msg import Marker
 from geometry_msgs.msg import Point
 
 import rospy
@@ -23,27 +25,28 @@ class PlanningHandle():
 
         self.planning_system = PlanningSystem()
 
-        self.subscribe_topics()
-        self.pub_route = None
-        self.publish_topics()
+        topic_map = rospy.get_param('~topic_map')
+        rospy.Subscriber(topic_map, Map, self.get_trajectory)
 
-    def subscribe_topics(self):
-        topic1 = rospy.get_param('/delaunay_detector/topic_map')
-        rospy.Subscriber(topic1, Map, self.get_trajectory)
+        topic_route = rospy.get_param('~topic_route')
+        self.pub_route = rospy.Publisher(topic_route, Trajectory, queue_size=1)
 
-    def publish_topics(self):
-        topic2 = rospy.get_param('/delaunay_detector/topic_route')
-        self.pub_route = rospy.Publisher(topic2, Trajectory,
-                                         queue_size=1)
+        self.bpublish_simplices = rospy.get_param('~send_simplices_marker')
+        if self.bpublish_simplices:
+            topic_route = rospy.get_param('~topic_simplices')
+            self.pub_marker = rospy.Publisher(topic_route, Marker, queue_size=1)
+
+
 
     def get_trajectory(self, msg):
-
         data = msg.cones  # List of cones
         self.planning_system.update_tracklimits(data)
         self.publish_msg()
 
     def publish_msg(self):
-        route = self.planning_system.calculate_path()
+        route, simplices = self.planning_system.calculate_path()
+        if simplices is not None and len(simplices) > 0 and self.bpublish_simplices:
+            self.publish_marker(simplices)
         msg = Trajectory()
         msg.trajectory = list()
         for midpoint in route:
@@ -55,3 +58,35 @@ class PlanningHandle():
 
         rospy.loginfo(msg)
         self.pub_route.publish(msg)
+
+    def publish_marker(self, simplices):
+        marker = Marker()
+        marker.header.frame_id = 'map'
+        marker.header.stamp = rospy.Time.now()
+
+        marker.ns = 'delaunay'
+        marker.id = 0
+        marker.type = Marker.LINE_LIST
+        marker.action = Marker.MODIFY
+        marker.scale.x = 0.1
+        marker.color.a = 1.0
+        marker.pose.orientation.x = 0.0
+        marker.pose.orientation.y = 0.0
+        marker.pose.orientation.z = 0.0
+        marker.pose.orientation.w = 1.0
+
+        marker.points = list()
+        cones = self.planning_system.cones
+        for simplex in simplices:
+            for a, b in combinations(simplex, 2):
+                point_a = Point()
+                point_a.x = cones[a, 0]
+                point_a.y = cones[a, 1]
+                marker.points.append(point_a)
+
+                point_b = Point()
+                point_b.x = cones[b, 0]
+                point_b.y = cones[b, 1]
+                marker.points.append(point_b)
+
+        self.pub_marker.publish(marker)


### PR DESCRIPTION
To avoid having to run the interface between `rviz` and each node separately, now the `planning` node can be configured to send its markers directly
https://github.com/ARUSfs/DRIVERLESS/blob/1ec644d12562e06865c627093eca7ddc67e58b0f/src/planning/delaunay_detector/src/planning_handle.py#L62-L92

Can be activated in 
https://github.com/ARUSfs/DRIVERLESS/blob/146a95c88cb7d686353cf861daa4336718f526c1/src/planning/delaunay_detector/config/delaunay.yaml#L4-L5